### PR TITLE
Store failed spoor requests in IndexedDB

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,12 +25,16 @@ const message = msg => {
 const register = flags => {
 	if ('serviceWorker' in navigator && flags.get('serviceWorker')) {
 		return navigator.serviceWorker.register('/__sw.js?cache-bust=1')
-			.then(registration => {
+			.then(() => {
 				message({
 					type: 'flagsUpdate',
 					flags: JSON.parse(JSON.stringify(flags)) // to avoid error caused by the getters
 				});
-				return registration;
+				return navigator.serviceWorker.ready(registration =>
+					registration.periodicSync.register({ tag: 'spoor' })
+						.then(() => registration)
+						.catch(() => registration)
+				);
 			});
 	} else {
 		return Promise.reject('Service Worker unavailable, or serviceWorker flag off');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bower": "^1.7.9",
     "eslint": "^3.0.1",
     "http-server": "^0.9.0",
+    "imports-loader": "^0.6.5",
     "lintspaces-cli": "^0.4.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "eslint": "^3.0.1",
     "http-server": "^0.9.0",
     "lintspaces-cli": "^0.4.0"
+  },
+  "dependencies": {
+    "indexeddb-promised": "^1.3.1"
   }
 }

--- a/src/__sw.js
+++ b/src/__sw.js
@@ -10,3 +10,6 @@ import './lib/polyfill';
 // import './lib/content';
 import './lib/comments';
 import './lib/myft';
+import './lib/spoor';
+
+toolbox.options.cache.name = 'next';

--- a/src/lib/spoor.js
+++ b/src/lib/spoor.js
@@ -1,0 +1,32 @@
+import toolbox from 'sw-toolbox';
+
+import DB from '../utils/db'
+
+const options = {
+	origin: 'https://spoor-api.ft.com'
+};
+
+const sync = () => { };
+
+toolbox.router.post('/ingest', request => {
+	const clonedRequest = request.clone();
+	// try and post the data, otherwise store in cache
+	return fetch(request)
+		.then(response => {
+			if (response.ok) {
+				// get the request's body and cach
+				return clonedRequest.json()
+					.then(data => {
+						const db = new DB('spoor');
+						return db.set(data.context.id, data)
+					})
+					.then(() => response)
+					.catch(err => {
+						console.log(err);
+						return response;
+					})
+			} else {
+				return response;
+			}
+		});
+}, options);

--- a/src/lib/spoor.js
+++ b/src/lib/spoor.js
@@ -43,7 +43,6 @@ self.addEventListener('periodicsync', ev => {
 
 toolbox.router.post('/ingest', request => {
 	const clonedRequest = request.clone();
-	// try and post the data, otherwise store in cache
 	return fetch(request)
 		.then(response => {
 			if (!response.ok) {
@@ -52,7 +51,7 @@ toolbox.router.post('/ingest', request => {
 					.then(() => response)
 					.catch(() => response);
 			} else {
-				// sync stored spoor data too
+				// sync stored spoor data
 				return syncData().then(() => response);
 			}
 		})

--- a/src/lib/spoor.js
+++ b/src/lib/spoor.js
@@ -6,27 +6,51 @@ const options = {
 	origin: 'https://spoor-api.ft.com'
 };
 
-const sync = () => { };
+const sync = () => {
+	const db = new DB('spoor');
+	return db.getAll()
+		.then(spoorDatas => {
+			const spoorRequests = spoorDatas.map(spoorData => {
+				const id = spoorData.context.id;
+				const spoorRequest = new Request(
+					'https://spoor-api.ft.com/ingest', { credentials: 'include', body: spoorData }
+				);
+				return fetch(spoorRequest)
+					.then(response => {
+						if (response.ok) {
+							return db.delete(id);
+						}
+					})
+					.catch(() => { })
+			});
+			return Promise.all(spoorRequests);
+		})
+		.catch(() => { });
+};
+
+self.addEventListener('periodicsync', ev => {
+	if (ev.tag === 'spoor') {
+		ev.waitUntil(sync());
+	}
+});
 
 toolbox.router.post('/ingest', request => {
 	const clonedRequest = request.clone();
 	// try and post the data, otherwise store in cache
 	return fetch(request)
 		.then(response => {
-			if (response.ok) {
-				// get the request's body and cach
+			if (!response.ok) {
+				// sending of spoor data failed, so store for later
 				return clonedRequest.json()
 					.then(data => {
 						const db = new DB('spoor');
 						return db.set(data.context.id, data)
 					})
 					.then(() => response)
-					.catch(err => {
-						console.log(err);
-						return response;
-					})
+					.catch(() => response);
 			} else {
-				return response;
+				// sync stored spoor data too
+				return sync().then(response);
 			}
 		});
 }, options);

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,0 +1,37 @@
+import idb from 'indexeddb-promised';
+
+console.log(idb);
+
+export default class {
+
+	constructor (storeName, { dbName = 'next', dbVersion = 1 } = { }) {
+		this.storeName = storeName;
+		this.dbPromise = idb.open(dbName, dbVersion, upgradeDB => {
+			upgradeDB.createObjectStore(storeName);
+		});
+	}
+
+	get (key) {
+		return this.dbPromise.then(db => {
+			return db.transaction(this.storeName)
+        		.objectStore(this.storeName).get(key);
+    		});
+	}
+
+	set (key, val) {
+		return this.dbPromise.then(db => {
+      		const tx = db.transaction(this.storeName, 'readwrite');
+      		tx.objectStore(this.storeName).put(val, key);
+      		return tx.complete;
+    	});
+	}
+
+  	delete (key) {
+    	return this.dbPromise.then(db => {
+      		const tx = db.transaction(this.storeName, 'readwrite');
+      		tx.objectStore(this.storeName).delete(key);
+      		return tx.complete;
+    	});
+  	}
+
+}

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,37 +1,30 @@
-import idb from 'indexeddb-promised';
-
-console.log(idb);
+import IndexedDBPromised from 'indexeddb-promised';
 
 export default class {
 
 	constructor (storeName, { dbName = 'next', dbVersion = 1 } = { }) {
 		this.storeName = storeName;
-		this.dbPromise = idb.open(dbName, dbVersion, upgradeDB => {
-			upgradeDB.createObjectStore(storeName);
-		});
+		const indexedDBPromised = new IndexedDBPromised(dbName);
+		this.idb = indexedDBPromised
+			.setVersion(dbVersion)
+			.addObjectStore({ name: storeName })
+			.build();
 	}
 
 	get (key) {
-		return this.dbPromise.then(db => {
-			return db.transaction(this.storeName)
-        		.objectStore(this.storeName).get(key);
-    		});
+		return this.idb[this.storeName].get(key);
+	}
+
+	getAll () {
+		return this.idb[this.storeName].getAll();
 	}
 
 	set (key, val) {
-		return this.dbPromise.then(db => {
-      		const tx = db.transaction(this.storeName, 'readwrite');
-      		tx.objectStore(this.storeName).put(val, key);
-      		return tx.complete;
-    	});
+		return this.idb[this.storeName].put(val, key);
 	}
 
-  	delete (key) {
-    	return this.dbPromise.then(db => {
-      		const tx = db.transaction(this.storeName, 'readwrite');
-      		tx.objectStore(this.storeName).delete(key);
-      		return tx.complete;
-    	});
-  	}
+	delete (key) {
+		return this.idb[this.storeName].delete(key);
+	}
 
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,5 +10,12 @@ module.exports = nWebpack({
 	entry: {
 		'./dist/__sw.js': './src/__sw.js'
 	},
-	include: [path.resolve('./src')]
+	include: [path.resolve('./src')],
+	loaders: [
+		{
+			test: /indexeddb-promised\.js$/,
+			loader: require.resolve('imports-loader'),
+			query: 'window=>self'
+		}
+	]
 });


### PR DESCRIPTION
Uses [indexeddb-promise](https://github.com/jakearchibald/indexeddb-promised), and give the periodic sync api a go (though don't think anything supports it)

Depends on https://github.com/Financial-Times/n-webpack/pull/15