### PR TITLE
Cache content, namespaced by uuid

### DIFF
--- a/src/__sw.js
+++ b/src/__sw.js
@@ -19,5 +19,3 @@ import './caches/ads';
 
 
 // import './push/myft';
-
-toolbox.options.cache.name = 'next';

--- a/src/offline/content.js
+++ b/src/offline/content.js
@@ -35,7 +35,7 @@ self.addEventListener('message', ev => {
 			.then(uuid => {
 				// only cache if we have a uuid
 				if (!uuid) {
-					return Promise.resolve([]);
+					return [];
 				}
 				// each content object contains a `url` and optional `cacheAge` property
 				const fetches = (msg.content || []).map(content => {


### PR DESCRIPTION
Assumes the response from `https://session-next.ft.com/uuid` stored in cache is the current user's