### PR TITLE
unregister service worker if cookie is too large

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,10 @@ const message = msg => {
 
 const register = flags => {
 	if ('serviceWorker' in navigator && flags.get('serviceWorker')) {
+		if (document.cookie.length > 4000) {
+			console.warn('Cookie is greater than 4000 characters - unregistering service worker due to potential failure to retrieve updates');
+			return unregister();
+		}
 		return navigator.serviceWorker.register('/__sw.js?cache-bust=1')
 			.then(registration =>
 				message({


### PR DESCRIPTION
In an ideal world there'd be an API to handle any failure to register/update, but there isn't... so playing extra safe for now until we figure out the shielding issue in fastly (probably after the www move) @matthew-andrews 