### PR TITLE
more persistent flag storage

### DIFF
--- a/src/push/myft.js
+++ b/src/push/myft.js
@@ -1,7 +1,7 @@
 /* global clients:false*/
 import eagerFetch from '../utils/eager-fetch';
 import track from '../utils/track';
-import {get as getFlag} from '../utils/flags';
+import {getFlag} from '../utils/flags';
 
 const title = 'New article in your myFT page';
 const icon = 'https://next-geebee.ft.com/assets/icons/myft-logo-pink-bg.png';

--- a/src/utils/flagged-toolbox.js
+++ b/src/utils/flagged-toolbox.js
@@ -1,5 +1,5 @@
 import toolbox from 'sw-toolbox';
-import {get as getFlag} from './flags';
+import {getFlag} from './flags';
 
 const strategies = {};
 ['networkFirst','cacheFirst','fastest','cacheOnly']

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -4,18 +4,68 @@
 // if flag === undefined can put in cache but not retrieve
 // if flag === true can put and retrieve from cache
 let flags = {}; //eslint-disable-line
+let dbPromise;
+
+function openDb () {
+	return new Promise(function(resolve, reject) {
+		const request = indexedDB.open('next', 1);
+
+		request.onupgradeneeded = function() {
+			request.result.createObjectStore('flags');
+		};
+
+		request.onsuccess = function() {
+			resolve(request.result);
+		};
+
+		request.onerror = function() {
+			reject(request.error);
+		};
+	});
+}
+
+function getStore() {
+	if (!dbPromise) {
+		dbPromise = openDb();
+	}
+	return dbPromise
+		.then(db => {
+			const transaction = db.transaction('flags', 'readwrite');
+			return transaction.objectStore('flags');
+		})
+}
+
+function setFlags (flags) {
+	getStore()
+		.then(store => {
+			const request = store.put(flags, 'flags');
+			request.onsuccess = () => {
+				flags = flags;
+			}
+		})
+}
+
+function updateFlags () {
+	getStore()
+		.then(store => {
+			const request = store.get('flags');
+			request.onsuccess = () => {
+				flags = request.result;
+			};
+		})
+}
+
 
 self.addEventListener('message', ev => {
 	const msg = ev.data;
 	if (msg.type === 'flagsUpdate') {
-		flags = Object.freeze(msg.flags);
+		setFlags(msg.flags);
 	}
 });
 
-self.addEventListener('activate', () => {
-	// do some stuff to enable/disable caches and other features based on value of current flags
-});
+updateFlags();
+setInterval(updateFlags, 1000 * 60 * 5)
 
-export function get (name) {
+export function getFlag (name) {
 	return flags[name]
 }


### PR DESCRIPTION
because service workers shut themselves down, losing global scope, and the spec is probably going to [change to allow browsers to spin up multiple sw instances](https://github.com/slightlyoff/ServiceWorker/issues/756), getting this out to make sure flags behave

@ironsidevsquincy 