### PR TITLE
new header on outgoing requests for precaching

### DIFF
--- a/src/offline/404-test.js
+++ b/src/offline/404-test.js
@@ -13,14 +13,14 @@ const cacheOptions = {
 
 const offlineLanding404Request = new Request ('/__offline/landing', {
 	credentials: 'same-origin',
-  headers: {
+  	headers: {
 		'x-requested-with': 'ft-sw'
 	}
 });
 
 const offlineTopStoriesRequest = new Request ('/__offline/top-stories', {
 	credentials: 'same-origin',
-  headers: {
+  	headers: {
 		'x-requested-with': 'ft-sw'
 	}
 });

--- a/src/offline/404-test.js
+++ b/src/offline/404-test.js
@@ -9,8 +9,11 @@ const cacheOptions = {
 	name: 'offline-ft-v1'
 };
 
-const offlineLandingRequest = new Request ('/__offline/landing', {
-	credentials: 'same-origin'
+const offlineLandingRequest = new Request ('/__offline/top-stories', {
+	credentials: 'same-origin',
+	headers: {
+		'x-requested-with': 'ft-sw'
+	}
 });
 
 // precache offlineLandingRequest response + its link headers

--- a/src/offline/404-test.js
+++ b/src/offline/404-test.js
@@ -13,14 +13,14 @@ const cacheOptions = {
 
 const offlineLanding404Request = new Request ('/__offline/landing', {
 	credentials: 'same-origin',
-  	headers: {
+	headers: {
 		'x-requested-with': 'ft-sw'
 	}
 });
 
 const offlineTopStoriesRequest = new Request ('/__offline/top-stories', {
 	credentials: 'same-origin',
-  	headers: {
+	headers: {
 		'x-requested-with': 'ft-sw'
 	}
 });

--- a/src/utils/offline-content.js
+++ b/src/utils/offline-content.js
@@ -19,7 +19,10 @@ export default function (url) {
 	}
 
 	req = new Request(_url.format(urlObj), {
-		credentials: 'same-origin'
+		credentials: 'same-origin',
+		headers: {
+			'x-requested-with': 'ft-sw'
+		}
 	});
 
 	return fetch(req);


### PR DESCRIPTION
So that we can make further access decisions in the offline app.
Outgoing precache requests will also have a 'x-requested-with'
header.