### PR TITLE
Request strategy

### DIFF
--- a/config/precache.js
+++ b/config/precache.js
@@ -1,26 +1,26 @@
 const appcache = {
 	fonts: [
-		'/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Regular.woff?',
-		'/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Semibold.woff?',
-		'/__origami/service/build/v2/files/o-fonts-assets@1.3.0/FinancierDisplayWeb-Regular.woff?'
+		'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Regular.woff?',
+		'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Semibold.woff?',
+		'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.0/FinancierDisplayWeb-Regular.woff?'
 	],
 	image: [
-		'/__origami/service/image/v2/images/raw/fticon-v1:hamburger?source=o-icons&tint=%23505050,%23505050&format=svg',
-		'/__origami/service/image/v2/images/raw/fticon-v1:search?source=o-icons&tint=%23505050,%23505050&format=svg',
-		'/__origami/service/image/v2/images/raw/ftlogo:brand-ft-masthead?source=o-header&tint=%23505050,%23505050&format=svg',
-		'/__origami/service/image/v2/images/raw/ftlogo:brand-myft?source=o-header&tint=%23505050,%23505050&format=svg'
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:hamburger?source=o-icons&tint=%23505050,%23505050&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:search?source=o-icons&tint=%23505050,%23505050&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft-masthead?source=o-header&tint=%23505050,%23505050&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-myft?source=o-header&tint=%23505050,%23505050&format=svg'
 	]
 }
 
 const sw = {
 	fonts: appcache.fonts.concat([
-		'/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Bold.woff?',
+		'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.0/MetricWeb-Bold.woff?',
 	]),
 	image: appcache.image.concat([
-		'/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23505050,%23505050&format=svg',
-		'/__origami/service/image/v2/images/raw/ftlogo:brand-nikkei-tagline?source=o-footer&format=svg',
-		'/__origami/service/image/v2/images/raw/ftlogo:brand-ft?source=next&tint=999999,999999',
-		'/__origami/service/image/v2/images/raw/fticon-v1:refresh?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg'
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23505050,%23505050&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-nikkei-tagline?source=o-footer&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft?source=next&tint=999999,999999',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:refresh?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg'
 	])
 }
 


### PR DESCRIPTION
Currently we always go to the network for fetch requests regardless of network state. This is safe as it means we'll always attempt to get the full version of article and not the offline version. However it has the penalty that we delay rendering the offline pages when genuinely offline as we have to wait for the network stack to fail first.

Therefore, this simply refactors the request routing strategy to use a `networkThenCache` strategy if `navigator.onLine` otherwise always use a `cacheThenNetwork` strategy.