### PR TITLE
Add an inifnite cache time to the font precache resources

### DIFF
--- a/src/caches/fonts.js
+++ b/src/caches/fonts.js
@@ -12,7 +12,7 @@ const options = {
 	}
 };
 
-precache(options.cache.name, precacheConfig.fonts);
+precache(options.cache.name, precacheConfig.fonts, { maxAge: -1 });
 
 // fonts route
 router.get('/__origami/service/build/v2/files/o-fonts-assets@:version/:font.woff', getHandler({strategy: 'cacheFirst'}), options);


### PR DESCRIPTION
This fixes the disappearing fonts problem :wink: 

Turns out the fonts would be evicted from the offline cache as we weren't explicitly declaring a cache time.