### PR TITLE
add 'arrow-down' and 'cross' icons to precache

### DIFF
--- a/config/precache.js
+++ b/config/precache.js
@@ -21,7 +21,9 @@ const sw = {
 		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-nikkei-tagline?source=o-footer&format=svg',
 		'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft?source=next&tint=999999,999999',
 		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:refresh?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg',
-		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon:pullquote?source=o-icons&tint=%23505050,%23505050&format=svg'
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon:pullquote?source=o-icons&tint=%23505050,%23505050&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-down?source=o-icons&tint=%2326747A,%2326747A&format=svg',
+		'https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg',
 	])
 }
 


### PR DESCRIPTION
Caches `arrow-down` and `cross` icons

Before:
![screenshot 2017-02-01 17 54 48](https://cloud.githubusercontent.com/assets/11544418/22519273/a65adeca-e8a7-11e6-94f4-c52868793e83.png)

After:
![screenshot 2017-02-01 17 48 56](https://cloud.githubusercontent.com/assets/11544418/22519282/b2ad645e-e8a7-11e6-9b52-4ae2a7cffc17.png)

