### PR TITLE
Pass pa11y tests

### DIFF
--- a/appcache/iframe.html
+++ b/appcache/iframe.html
@@ -1,3 +1,3 @@
 {{#if @root.flags.appcache}}
-<iframe src="/__appcache-manifest-loader{{#if @root.flags.offlineLandingTestPage}}-landing{{/if}}.html" style="width:0; height:0; visibility:hidden; position:absolute; border:none" />
+<iframe src="/__appcache-manifest-loader{{#if @root.flags.offlineLandingTestPage}}-landing{{/if}}.html" style="width:0; height:0; visibility:hidden; position:absolute; border:none" title="Please ignore" aria-hidden="true" />
 {{/if}}


### PR DESCRIPTION
Unfortunately we [can’t just add `aria-hidden` and omit a title](https://github.com/squizlabs/HTML_CodeSniffer/blob/master/Standards/WCAG2AAA/Sniffs/Principle2/Guideline2_4/2_4_1.js#L49)

@lc512k 