### PR TITLE
fix appache manifest cache section

### DIFF
--- a/appcache/generate.js
+++ b/appcache/generate.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const precache = require('../config/precache').appcache;
 const urls = Object.keys(precache)
 	.reduce((arr, key) => {
-		return arr.concat('https://www.ft.com' + precache[key]);
+		return arr.concat(precache[key].map(path => 'https://www.ft.com' + path));
 	}, []);
 
 const landing = process.argv[2] === 'landing';


### PR DESCRIPTION
the old code was generating this:

```
CACHE:
https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff?,/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff?,/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff?
https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft-masthead?source=o-header&tint=%2333302E,%2333302E&format=svg,/__origami/service/image/v2/images/raw/fticon-v1:hamburger?source=o-icons&tint=%2333302E,%2333302E&format=svg,/__origami/service/image/v2/images/raw/fticon-v1:search?source=o-icons&tint=%2333302E,%2333302E&format=svg,/__origami/service/image/v2/images/raw/ftlogo:brand-myft?source=o-header&tint=%2333302E,%2333302E&format=svg
```

when really we want:

```
CACHE:
https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff
https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff
https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff
https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft-masthead?source=o-header&tint=%2333302E,%2333302E&format=svg
https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:hamburger?source=o-icons&tint=%2333302E,%2333302E&format=svg
https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:search?source=o-icons&tint=%2333302E,%2333302E&format=svg
https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-myft?source=o-header&tint=%2333302E,%2333302E&format=svg
```

which this PR will do