### PR TITLE
Delete temp flag passing to SW via message

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,12 +52,6 @@ const register = flags => {
 							if (!navigator.serviceWorker.controller) {
 								window.postMessage({command: 'precacheDone'}, '*');
 							}
-							//only needed while rolling out the new SW wit new flags mechanism
-							//TODO delete in a few days 9/1/18
-							message({
-								type: 'flagsUpdate',
-								flags: JSON.parse(JSON.stringify(flags))
-							});
 							break;
 
 						case 'redundant':


### PR DESCRIPTION
 🐿 v2.5.16

Hangover from this PR: https://github.com/Financial-Times/n-service-worker/pull/138.

Should stop a lot of the "Service Worker unavailable" errors being triggered and sent to sentry