### PR TITLE
Fix max age test 🐿 v2.12.5

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,14 +48,14 @@ const register = flags => {
 
 					installingWorker.onstatechange = function () {
 						switch (installingWorker.state) {
-						case 'installed':
-							if (!navigator.serviceWorker.controller) {
-								window.postMessage({command: 'precacheDone'}, '*');
-							}
-							break;
+							case 'installed':
+								if (!navigator.serviceWorker.controller) {
+									window.postMessage({command: 'precacheDone'}, '*');
+								}
+								break;
 
-						case 'redundant':
-							throw Error('The installing service worker became redundant.');
+							case 'redundant':
+								throw Error('The installing service worker became redundant.');
 						}
 
 					};

--- a/test/integration/cache.spec.js
+++ b/test/integration/cache.spec.js
@@ -365,7 +365,7 @@ describe('cache', () => {
 					.then(cache => cache.set(testUrl))
 					.then(() => new DB('requests', { dbName: 'next:test-cache'}).get(testUrl))
 					.then(inDb => {
-						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 1000);
+						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 500);
 					});
 			});
 
@@ -401,7 +401,7 @@ describe('cache', () => {
 					.then(cache => cache.set(testUrl))
 					.then(() => new DB('requests', { dbName: 'next:test-cache'}).get(testUrl))
 					.then(inDb => {
-						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 500);
+						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 1000);
 					});
 			});
 

--- a/test/integration/cache.spec.js
+++ b/test/integration/cache.spec.js
@@ -365,7 +365,7 @@ describe('cache', () => {
 					.then(cache => cache.set(testUrl))
 					.then(() => new DB('requests', { dbName: 'next:test-cache'}).get(testUrl))
 					.then(inDb => {
-						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 500);
+						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 1000);
 					});
 			});
 

--- a/test/integration/cache.spec.js
+++ b/test/integration/cache.spec.js
@@ -365,7 +365,7 @@ describe('cache', () => {
 					.then(cache => cache.set(testUrl))
 					.then(() => new DB('requests', { dbName: 'next:test-cache'}).get(testUrl))
 					.then(inDb => {
-						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 500);
+						expect(inDb.expires).to.be.closeTo(now + (60 * 1000), 1000);
 					});
 			});
 
@@ -386,7 +386,7 @@ describe('cache', () => {
 					.then(cache => cache.set(testUrl, {maxAge: 200}))
 					.then(() => new DB('requests', { dbName: 'next:test-cache'}).get(testUrl))
 					.then(inDb => {
-						expect(inDb.expires).to.be.closeTo(now + (200 * 1000), 500);
+						expect(inDb.expires).to.be.closeTo(now + (200 * 1000), 1000);
 					});
 			});
 


### PR DESCRIPTION
Fixes some of  the `cache cache invalidation` tests. The sw database is accessed async, so testing the expiry of an entry cannot be done accurately. The test was testing the expiry value  +/- 500ms to allow for discrepancies in async code execution time. On circle, this was just over the 500ms mark so I've increased this to +/- 1000ms to make sure this doesn't break again, but still accurate enough.