### PR TITLE
replaced n-internal-tools for n-express

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -1,25 +1,24 @@
-const internalTool = require('@financial-times/n-internal-tool');
+const nExpress = require('@financial-times/n-express');
 const chalk = require('chalk');
 const path = require('path');
-
-const fixtures = require('./fixtures.json');
 
 const errorHighlight = chalk.bold.red;
 const highlight = chalk.bold.green;
 
-const app = internalTool({
-	s3o: false,
-	partialsDirectory: path.resolve(__dirname, '..'),
+const app = module.exports = nExpress({
+	name: 'public',
 	systemCode: 'n-service-worker',
-	viewsDirectory: '/demo'
+	withFlags: false,
+	withConsent: false,
+	withServiceMetrics: false,
+	withAnonMiddleware: false,
+	demo: true,
+	withBackendAuthentication: false,
 });
 
-app.get('/', (req, res) => {
-	res.render('demo', Object.assign({
-		title: 'Test App',
-		layout: 'vanilla',
-	}, fixtures));
-});
+app.use('/', nExpress.static(path.join(process.cwd(), '/demos'), { redirect: false }));
+app.use('/public', nExpress.static(path.join(process.cwd(), '/public'), { redirect: false }));
+
 
 function runPa11yTests () {
 	const spawn = require('child_process').spawn;

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,27 +513,26 @@
       }
     },
     "@financial-times/n-express": {
-      "version": "19.23.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-19.23.4.tgz",
-      "integrity": "sha512-dWbHXAwKz8LtYfGy6BDnxYU9Uulucl6kJE0lyQvhRd+pRlvQw/Yz7l1wqeC5jwYRx1qK6IRcbg740eOltLIQmA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-22.4.1.tgz",
+      "integrity": "sha512-eBi1CRmvXObqZpRH6CsM8TGuSBfqeWlHc0ET5rHXlWlLpCMuS41XfH3JQZ9KEIsDdANwEQ9RvDkI+LKXvU/GuA==",
       "dev": true,
       "requires": {
-        "@financial-times/n-flags-client": "^9.1.5",
-        "@financial-times/n-logger": "^6.0.0",
-        "@financial-times/n-raven": "^3.0.3",
+        "@financial-times/n-flags-client": "^10.0.0",
+        "@financial-times/n-logger": "^8.0.0",
+        "@financial-times/n-raven": "^5.0.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.16.3",
-        "ip": "^1.1.5",
-        "isomorphic-fetch": "^2.2.1",
-        "n-health": "^3.0.0",
-        "next-metrics": "^3.1.40"
+        "isomorphic-fetch": "^3.0.0",
+        "n-health": "^5.0.5",
+        "next-metrics": "^5.1.0"
       },
       "dependencies": {
         "@financial-times/n-logger": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-          "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-8.0.1.tgz",
+          "integrity": "sha512-Ezy1Xg9MHr6rgQf0AuYMcv/idRvAZ9ba7UYR7qov2rAtjMXPl6daS89J+j+uTCedIYVUcvC+Plitme17zARJYg==",
           "dev": true,
           "requires": {
             "json-stringify-safe": "^5.0.1",
@@ -541,16 +540,20 @@
             "winston": "^2.4.0"
           }
         },
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-          "dev": true
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
         },
         "next-metrics": {
-          "version": "3.1.41",
-          "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-3.1.41.tgz",
-          "integrity": "sha512-vUPQzfoo9kIMYJwhBg82BWDVsrntROZNn6ZPpq6jIV7LUz5KfNeKWOHE42vGeapghEK6y3xtbCe02VRDrFE+zw==",
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.3.tgz",
+          "integrity": "sha512-Yu3jXlORu2U/5hiGmO4DwTy8OZXJCfPCI7CidbT2JObVfWmQekwaX8HaWmlI4gjW/d5umOKyCqbZJFjVVtQd4A==",
           "dev": true,
           "requires": {
             "@financial-times/n-logger": "^5.5.6",
@@ -567,6 +570,26 @@
                 "isomorphic-fetch": "^2.2.1",
                 "request": "^2.83.0",
                 "winston": "^2.4.0"
+              }
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+              "dev": true,
+              "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+              "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+              "dev": true,
+              "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
               }
             }
           }
@@ -594,9 +617,9 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-9.4.3.tgz",
-      "integrity": "sha512-Wlu0DJKWWB3xy1W10DD5Gqlw1t0o0dhKz+9OkQgmvgcHM0pds7s4tciyZR/b/4VO5CYoyyNgoEop/m9DW3Lngg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-10.1.0.tgz",
+      "integrity": "sha512-526t74bMX/gbU4ok5vp9pU6Lb7DBda5UISUIsw7nto8iapPX1WXBteTyBQdutfR+Mwl180fqkkeh45RcefWrog==",
       "dev": true,
       "requires": {
         "@financial-times/n-logger": "^6.0.0",
@@ -800,20 +823,6 @@
         }
       }
     },
-    "@financial-times/n-handlebars": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-handlebars/-/n-handlebars-1.22.1.tgz",
-      "integrity": "sha512-hm/85DGH71hs0oJ5cefrt7j761QTAYFTO/OkM5cdlFGa1yDLktuGt6BjoTZL3gHML0nFO1qrMt5p4PSZIhhMXg==",
-      "dev": true,
-      "requires": {
-        "@financial-times/n-image": "^5.0.0",
-        "@financial-times/n-topic-card": "^2.0.0",
-        "dateformat": "^1.0.11",
-        "denodeify": "^1.2.1",
-        "express-handlebars": "^3.0.2",
-        "handlebars": "^4.0.0"
-      }
-    },
     "@financial-times/n-heroku-tools": {
       "version": "6.32.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-heroku-tools/-/n-heroku-tools-6.32.0.tgz",
@@ -849,48 +858,6 @@
           "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
         }
-      }
-    },
-    "@financial-times/n-image": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-image/-/n-image-5.1.3.tgz",
-      "integrity": "sha512-b0pNytf1ecqZdkyEW1Uo7gvOg6dnhI/N6TnTeqVi0PcuJv70OJA/IPBphz8HYVV3ylQrPX4ai1FLSJu5MzPuaw==",
-      "dev": true,
-      "requires": {
-        "@financial-times/n-logger": "^6.0.0"
-      },
-      "dependencies": {
-        "@financial-times/n-logger": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-          "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
-          "dev": true,
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "node-fetch": "^2.6.0",
-            "winston": "^2.4.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
-      }
-    },
-    "@financial-times/n-internal-tool": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-internal-tool/-/n-internal-tool-2.3.4.tgz",
-      "integrity": "sha512-eZVrIGsKEmVXnlvbE7mH9uLtqA3Jv5sI4FVgSMGGse6kFrN2CogzsI1m8TEwu8V9eFsIXYfqa9nRIe+tpfKeHg==",
-      "dev": true,
-      "requires": {
-        "@financial-times/n-express": "^19.21.4",
-        "@financial-times/n-handlebars": "^1.19.1",
-        "@financial-times/s3o-middleware": "^3.0.0"
       }
     },
     "@financial-times/n-logger": {
@@ -933,78 +900,33 @@
       }
     },
     "@financial-times/n-raven": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-3.0.4.tgz",
-      "integrity": "sha512-3Y1SbN4po9lq+uwoM2qmLznLmXe0enp5mNiefPH8qrMc7pKle1z9id9+UjP1mec8Q7XMArW6Ij0DWrpiaZVMrQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-5.0.2.tgz",
+      "integrity": "sha512-ML+aHX+jSe7K5LiHUiO43VHIz7Vhkw8ky1k8IY59SEtjLdmTh3e0pppmLSnFHs7V8Y8Za25l7Mwzc13HP7eEQg==",
       "dev": true,
       "requires": {
-        "@financial-times/n-logger": "^5.5.7",
+        "@financial-times/n-logger": "^8.0.0",
         "raven": "^2.3.0"
-      }
-    },
-    "@financial-times/n-topic-card": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-topic-card/-/n-topic-card-2.1.3.tgz",
-      "integrity": "sha1-RB5CAhEwsta0CXKTwmSrkeshuvo=",
-      "dev": true
-    },
-    "@financial-times/s3o-middleware": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/s3o-middleware/-/s3o-middleware-3.0.1.tgz",
-      "integrity": "sha512-lIENCt1ONK6g822DJ809slH9n06qJBjV+ySrnK17LXMD/UWEr0tjiKE6sL9FKNz6H6J2syNfDTZJwIArqHXPkA==",
-      "dev": true,
-      "requires": {
-        "@financial-times/s3o-middleware-utils": "^2.0.0",
-        "body-parser": "^1.14.1",
-        "cookie": "^0.3.1",
-        "debug": "^4.1.1"
-      }
-    },
-    "@financial-times/s3o-middleware-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/s3o-middleware-utils/-/s3o-middleware-utils-2.0.0.tgz",
-      "integrity": "sha512-TIjzld6EvYxugRHQE1kXhurgRoRlCZJ9tfJNZKbZfT/rrU81+U+47BkBS4XKJwB4cfiQ97oEYZBCMpHW1pKXfg==",
-      "dev": true,
-      "requires": {
-        "cookie": "^0.3.1",
-        "debug": "^4.1.1",
-        "ft-poller": "^3.0.1",
-        "got": "^9.6.0",
-        "node-rsa": "^1.0.2"
       },
       "dependencies": {
-        "got": {
-          "version": "9.6.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+        "@financial-times/n-logger": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-8.0.1.tgz",
+          "integrity": "sha512-Ezy1Xg9MHr6rgQf0AuYMcv/idRvAZ9ba7UYR7qov2rAtjMXPl6daS89J+j+uTCedIYVUcvC+Plitme17zARJYg==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^0.14.0",
-            "@szmarczak/http-timer": "^1.1.2",
-            "cacheable-request": "^6.0.0",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^4.1.0",
-            "lowercase-keys": "^1.0.1",
-            "mimic-response": "^1.0.1",
-            "p-cancelable": "^1.0.0",
-            "to-readable-stream": "^1.0.0",
-            "url-parse-lax": "^3.0.0"
+            "json-stringify-safe": "^5.0.1",
+            "node-fetch": "^2.6.0",
+            "winston": "^2.4.0"
           }
         },
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-          "dev": true
-        },
-        "url-parse-lax": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
           "dev": true,
           "requires": {
-            "prepend-http": "^2.0.0"
+            "whatwg-url": "^5.0.0"
           }
         }
       }
@@ -1062,12 +984,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -1129,15 +1045,6 @@
       "requires": {
         "remark": "^13.0.0",
         "unist-util-find-all-after": "^3.0.2"
-      }
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^1.0.1"
       }
     },
     "@types/mdast": {
@@ -1467,12 +1374,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2989,38 +2890,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "dev": true,
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        }
-      }
-    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3450,15 +3319,6 @@
       "dev": true,
       "requires": {
         "is-regexp": "^2.0.0"
-      }
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -3991,186 +3851,6 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
       "dev": true
     },
-    "dateformat": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
-    },
     "debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -4216,15 +3896,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -4244,12 +3915,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "defer-to-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
     "define-properties": {
@@ -5719,19 +5384,6 @@
         }
       }
     },
-    "express-handlebars": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.1.0.tgz",
-      "integrity": "sha512-7QlaXnSREMmN5P2o4gmpUZDfJlLtfBka9d6r7/ccXaU7rPp76odw9YYtwZYdIiha2JqwiaG6o2Wu6NZJQ0u7Fg==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.2",
-        "handlebars": "^4.1.2",
-        "object.assign": "^4.1.0",
-        "promise": "^8.0.2"
-      }
-    },
     "ext": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
@@ -6283,16 +5935,6 @@
         "nan": "^2.12.1"
       }
     },
-    "ft-poller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ft-poller/-/ft-poller-3.0.1.tgz",
-      "integrity": "sha512-f+cvp9uuHf45utNXgDqyGfQECAT4AytrnDprd4H6O5cI4RwWtH81eeCgtSHkiLYKeIM8vtpZPrpMaF22V560/w==",
-      "dev": true,
-      "requires": {
-        "isomorphic-fetch": "^2.0.0",
-        "n-eager-fetch": "^2.0.0"
-      }
-    },
     "ftp": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
@@ -6729,27 +6371,6 @@
         }
       }
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6980,12 +6601,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^3.1.1"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
     },
     "http-errors": {
       "version": "1.8.1",
@@ -7798,12 +7413,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -7919,12 +7528,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-loader": {
@@ -8390,15 +7993,6 @@
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
-    },
-    "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -9303,12 +8897,6 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
-    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9634,9 +9222,9 @@
       }
     },
     "n-health": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-3.4.0.tgz",
-      "integrity": "sha512-nkdt6N/mkXIen/yZxoBum9uIha5p/Z8Jj/xLTOqKI728M9DdAbLH8v/BtDRPj4+buY91U5ZXDKMxqK6bG+6qsg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-5.0.6.tgz",
+      "integrity": "sha512-/WbW/YQkCtjEuq3PGoeH2bd8hRhQtchmP2BO3xMAL9J2RGeDNd0GTFboQuW+gGE+36RWDFXO6fM0s5sH7RgPtA==",
       "dev": true,
       "requires": {
         "@financial-times/n-logger": "^6.0.0",
@@ -10000,15 +9588,6 @@
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
-    "node-rsa": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
-      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
-      "dev": true,
-      "requires": {
-        "asn1": "^0.2.4"
-      }
-    },
     "node-vault": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.5.10.tgz",
@@ -10115,12 +9694,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
-      "dev": true
-    },
-    "normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "notify-saucelabs": {
@@ -10456,12 +10029,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
     "p-finally": {
@@ -11302,15 +10869,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.6"
-      }
-    },
     "promise-rat-race": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/promise-rat-race/-/promise-rat-race-1.5.1.tgz",
@@ -11990,15 +11548,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -13813,12 +13362,6 @@
         }
       }
     },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "dev": true
-    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -13998,13 +13541,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "uglify-js": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
-      "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
-      "dev": true,
-      "optional": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "devDependencies": {
+    "@financial-times/n-express": "^22.4.1",
     "@financial-times/n-gage": "^8.3.2",
     "@financial-times/n-heroku-tools": "^6.31.1",
-    "@financial-times/n-internal-tool": "^2.1.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
Replaced n-internal-tools for n-express

The file `fixtures.json` is no longer in the repository, so I've updated the demo so you just need to visit: `http://localhost:5005/demo.html`