### PR TITLE
fix npm7 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,6 @@ jobs:
           name: Install project dependencies
           command: make install
       - run:
-          name: shared-helper / npm-install-peer-deps
-          command: .circleci/shared-helpers/helper-npm-install-peer-deps
-      - run:
           name: shared-helper / npm-update
           command: .circleci/shared-helpers/helper-npm-update
       - run:


### PR DESCRIPTION
remove npm-install-peer-deps CI step since it's redundant after the migration to npm7