### PR TITLE
Set NPM with exact version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - checkout
       - node/install-npm:
-          version: "7"
+          version: "7.20.2"
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1


### PR DESCRIPTION
This is to prevent issues with circleCI script and the way it resolves npm version. Context [here](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1652356882216429)