### PR TITLE
ADSDEV-1459: Remove deprecated host for fetching the google publisher…

### DIFF
--- a/src/caches/ads.js
+++ b/src/caches/ads.js
@@ -58,7 +58,7 @@ export default function init (cacheHandler) {
 	});
 
 	router.get('/tag/js/gpt.js', cacheHandler, {
-		origin: 'https://www.googletagservices.com',
+		origin: 'https://securepubads.g.doubleclick.net',
 		cache: getCacheOptions(7)
 	});
 

--- a/test/unit/caches/ads.spec.js
+++ b/test/unit/caches/ads.spec.js
@@ -63,9 +63,9 @@ describe('Ads cache', () => {
 			});
 		});
 
-		it('GET https://www.googletagservices.com/tag/js/gpt.js', () => {
+		it('GET https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {
 			expect(routerStub.get).to.have.been.calledWith('/tag/js/gpt.js', handlerStub, {
-				origin: 'https://www.googletagservices.com',
+				origin: 'https://securepubads.g.doubleclick.net',
 				cache: getCacheOptions(7)
 			});
 		});


### PR DESCRIPTION
A maintenance update to keep resolving ad scripts. 

Context: Google will stop serving the google publisher tag from the googletagservices host. 
Change resolution to the long term supported domain.