### PR TITLE
chore: update to node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.17"
         type: string
 
   workspace_root: &workspace_root ~/project
@@ -83,13 +83,11 @@ jobs:
     <<: *container_config
     steps:
       - checkout
-      - node/install-npm:
-          version: "7.20.2"
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - run:
           name: Install project dependencies
@@ -145,7 +143,7 @@ jobs:
       - *attach_workspace
       - run:
           name: Deploy
-          command: make deploy
+          command: NODE_OPTIONS="--no-experimental-fetch" make deploy
           environment:
             JEST_JUNIT_OUTPUT: test-results/jest/results.xml
             MOCHA_FILE: test-results/mocha/results.xml
@@ -161,14 +159,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
   build-test-publish:
     jobs:
       - build:
@@ -177,7 +175,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -186,13 +184,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.20", "18.17" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.17
   build-test-deploy-main:
     jobs:
       - build:
@@ -201,7 +199,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_only_main
@@ -210,12 +208,12 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - deploy:
           filters:
             <<: *filters_only_main
           requires:
-            - test-v16.14
+            - test-v18.17
 
   build-test-deploy-qa:
     jobs:
@@ -225,7 +223,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_qa_tag
@@ -234,12 +232,12 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - deploy:
           filters:
             <<: *filters_qa_tag
           requires:
-            - test-v16.14
+            - test-v18.17
 
   build-test-deploy-canary:
     jobs:
@@ -249,7 +247,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_canary_tag
@@ -258,12 +256,12 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - deploy:
           filters:
             <<: *filters_canary_tag
           requires:
-            - test-v16.14
+            - test-v18.17
 
   build-test-deploy-production:
     jobs:
@@ -273,7 +271,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_production_tag
@@ -282,12 +280,12 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - deploy:
           filters:
             <<: *filters_production_tag
           requires:
-            - test-v16.14
+            - test-v18.17
 
   nightly:
     triggers:
@@ -301,7 +299,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -309,7 +307,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14", "14.19"]
+              node-version: [ "16.20", "18.17" ]
 
 notify:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ node_modules/@financial-times/n-gage/index.mk:
 test: verify unit-test integration-test
 
 build-dev:
-	webpack --watch --debug
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --watch --debug
 
 PORT ?= 3010
 
 build:
-	webpack --bail --debug
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --bail --debug
 
 build-production:
-	webpack --bail -p
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --bail -p
 
 # TODO: Add proper integration tests with nightwatch
 integration-test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-service-worker",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "idb": "^2.0.4",
@@ -56,8 +55,8 @@
         "webpack": "^3.8.1"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,15 @@
   },
   "description": "Global service worker component for next.ft.com",
   "volta": {
-    "node": "16.14.2",
-    "npm": "7.20.2"
+    "node": "18.17.1"
   },
   "engines": {
-    "node": "14.x || 16.x",
-    "npm": "7.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "scripts": {
     "start": "make run -j2",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "idb": "^2.0.4",


### PR DESCRIPTION
# Description

PR to achieve upgrade to Node v18. This is part of [migrating to Node v.18 Initiative](https://financialtimes.atlassian.net/browse/CON-2706).

In order to achieve the migration, it has been used the following [migration script](https://github.com/Financial-Times/platform-scripts/tree/7c571c9e8e5e452e6cf16f36fc44b0769c71551f/upgrade-node-18).

I know this is deprecated but I believe **next-myft-page** update is failing because of the difference in node version: https://app.circleci.com/pipelines/github/Financial-Times/next-myft-page/6967/workflows/9944ce1c-efa4-4595-a624-fd2b3c4a3c00/jobs/29080 