### PR TITLE
Remove check for cookie length

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,11 +24,6 @@ const message = msg => {
 
 const register = flags => {
 	if ('serviceWorker' in navigator && flags.get('serviceWorker')) {
-		if (document.cookie.length > 4000) {
-			console.warn('Cookie is greater than 4000 characters - unregistering service worker due to potential failure to retrieve updates'); //eslint-disable-line
-			return unregister();
-		}
-
 		const sampleUsers = require('./src/utils/sampleUsers').sampleUsers;
 
 		const swEnv = flags.get('swQAVariant') ||


### PR DESCRIPTION
Allow the service worker to register even if the cookie length is greater than 4000.

Currently many users have cookies longer than 4000 so this will be preventing users from choosing to receive instant alerts as push notifications and in some cases it might be preventing users who have chosen that delivery method from receiving them.

Looking up service worker documentation and examples I can no longer find any reference for the need to check the cookie length. As a lot has changed in browsers and APIs such as service workers in the last 7 years I am hoping that this was a quirk of the API in its early days.