### PR TITLE
Update deprecated Buffer usage

### DIFF
--- a/src/utils/track.js
+++ b/src/utils/track.js
@@ -12,7 +12,7 @@ export default function (data) {
 		headers: {
 			'Accept': 'application/json',
 			'Content-Type': 'application/json',
-			'Content-Length': new Buffer(JSON.stringify(data)).length
+			'Content-Length': Buffer.from(JSON.stringify(data)).length
 		},
 		body: JSON.stringify(data)
 	}).catch(() => {});


### PR DESCRIPTION
This PR updates the usage of `new Buffer` which will output the following warning:

> (node:9017) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

#### References
- [Stack Overflow: DeprecationWarning: Buffer() is deprecated due to security and usability issues when I move my script to another server](https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues#answer-52257416)

```js
new Buffer(number)            // Old
Buffer.alloc(number)          // New

new Buffer(string)            // Old
Buffer.from(string)           // New

new Buffer(string, encoding)  // Old
Buffer.from(string, encoding) // New

new Buffer(...arguments)      // Old
Buffer.from(...arguments)     // New
```