### PR TITLE
Fix No rule to make target 'echo' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ node_modules/@financial-times/n-gage/index.mk:
 
 .PHONY: demo
 
-test: echo "no tests"
+test: verify
 
 build-dev:
 	webpack --watch --debug


### PR DESCRIPTION
We needed to release [this change](https://github.com/Financial-Times/n-service-worker/pull/202) to decommission n-service-worker.

However no test causes an error in the release pipeline
![Screenshot 2024-03-18 at 12 49 26](https://github.com/Financial-Times/n-service-worker/assets/21194161/de63a5c5-76b3-4ec4-b03b-de917cdbf002)
